### PR TITLE
Dom title

### DIFF
--- a/R/plot_dominance.R
+++ b/R/plot_dominance.R
@@ -12,7 +12,6 @@
 #' was fitted with a single term, this one is taken.
 #' @param relative Logical specifying whether to have relative or absolute scales.
 #' Defaults to \code{TRUE}.
-#' @param title Title of plot.
 #' @param width Width of bars. Default to \code{NULL}, which means it is automatically
 #' determined based on the minimum grid spacing in \code{x}.
 #'
@@ -25,7 +24,7 @@
 #' # or by typing the following in the console:
 #' # vignette("Dominance")
 #'
-plot_dominance <- function(x, axis = NULL, term = NULL, relative = TRUE, title = "Dominance Plot",
+plot_dominance <- function(x, axis = NULL, term = NULL, relative = TRUE,
                             width = NULL)
 {
 
@@ -59,7 +58,6 @@ plot_dominance <- function(x, axis = NULL, term = NULL, relative = TRUE, title =
     ggplot2::geom_bar(position=position,stat="identity")+
     ggplot2::theme_minimal()+
     viridis::scale_fill_viridis(discrete = T) +
-    ggplot2::ggtitle(title)+
     ggplot2::ylab("Relative Influence") +
     ggplot2::xlab(axis) +
     ggplot2::labs(fill = "Cohort")

--- a/R/plot_heterogeneity.R
+++ b/R/plot_heterogeneity.R
@@ -10,7 +10,6 @@
 #' @param type Character specifying which type of plot. Either \code{"Q"} for the test statistic
 #' or \code{"p"} for the p-value. Defaults to \code{"Q"}.
 #' @param alpha_thresh Significance level. Defaults to \code{.05}.
-#' @param ... Other arguments to ggplot.
 #'
 #' @return A ggplot object.
 #' @export
@@ -23,7 +22,7 @@
 #' # vignette("heterogeneity")
 #'
 #'
-plot_heterogeneity <- function(x, axis = x$xvars, term = NULL, type = "Q", alpha_thresh = .05, ...)
+plot_heterogeneity <- function(x, axis = x$xvars, term = NULL, type = "Q", alpha_thresh = .05)
 {
 
   type <- match.arg(type, c("p", "Q"))
@@ -31,8 +30,8 @@ plot_heterogeneity <- function(x, axis = x$xvars, term = NULL, type = "Q", alpha
   dat <- make_heterogeneity_data(x, axis = axis, term = term)
 
   gp <- switch(type,
-         "p" = plot_heterogeneity_p(dat, axis, alpha_thresh, ...),
-         "Q" = plot_heterogeneity_q(dat, axis, alpha_thresh, ...)
+         "p" = plot_heterogeneity_p(dat, axis, alpha_thresh),
+         "Q" = plot_heterogeneity_q(dat, axis, alpha_thresh)
          )
 
   return(gp)
@@ -78,10 +77,10 @@ make_heterogeneity_data <- function(x, axis = x$xvars, term = NULL)
 #' @inheritParams plot_heterogeneity
 #'
 #' @return ggproto object
-plot_heterogeneity_p <- function(data, axis, alpha_thresh, ...){
+plot_heterogeneity_p <- function(data, axis, alpha_thresh){
   ggplot2::ggplot(data = data,
                   ggplot2::aes(x = .data$x, y = .data$QEp)) +
-    ggplot2::geom_line(...) +
+    ggplot2::geom_line() +
     ggplot2::geom_hline(yintercept = alpha_thresh, lty = 2) +
     ggplot2::scale_y_continuous(trans = 'log2') +
     ggplot2::theme_minimal() +
@@ -98,7 +97,7 @@ plot_heterogeneity_p <- function(data, axis, alpha_thresh, ...){
 #' @inheritParams plot_heterogeneity
 #'
 #' @return ggproto object
-plot_heterogeneity_q <- function(data, axis, alpha_thresh, ...){
+plot_heterogeneity_q <- function(data, axis, alpha_thresh){
   # TODO: øystein, please check whether this is the correct approximation
 
   data <- dplyr::mutate(data,
@@ -108,12 +107,13 @@ plot_heterogeneity_q <- function(data, axis, alpha_thresh, ...){
 
   ggplot2::ggplot(data = data,
                   ggplot2::aes(x = .data$x, y = .data$QE)) +
-    ggplot2::geom_ribbon(...,
+    ggplot2::geom_ribbon(
       mapping = ggplot2::aes(
         ymin = .data$QE + stats::qnorm(!!alpha_thresh / 2) * .data$Qse,
-        ymax = .data$QE + stats::qnorm(1 - !!alpha_thresh / 2) * .data$Qse)
+        ymax = .data$QE + stats::qnorm(1 - !!alpha_thresh / 2) * .data$Qse),
+      alpha = .3
     ) +
-    ggplot2::geom_line(...) +
+    ggplot2::geom_line() +
     ggplot2::theme_minimal() +
     ggplot2::labs(y = "Heterogeneity (Q)",
                   x = axis)

--- a/man/plot_dominance.Rd
+++ b/man/plot_dominance.Rd
@@ -4,14 +4,7 @@
 \alias{plot_dominance}
 \title{Dominance plot}
 \usage{
-plot_dominance(
-  x,
-  axis = NULL,
-  term = NULL,
-  relative = TRUE,
-  title = "Dominance Plot",
-  width = NULL
-)
+plot_dominance(x, axis = NULL, term = NULL, relative = TRUE, width = NULL)
 }
 \arguments{
 \item{x}{Object returned by \code{\link{metagam}}.}
@@ -25,8 +18,6 @@ was fitted with a single term, this one is taken.}
 
 \item{relative}{Logical specifying whether to have relative or absolute scales.
 Defaults to \code{TRUE}.}
-
-\item{title}{Title of plot.}
 
 \item{width}{Width of bars. Default to \code{NULL}, which means it is automatically
 determined based on the minimum grid spacing in \code{x}.}

--- a/man/plot_heterogeneity.Rd
+++ b/man/plot_heterogeneity.Rd
@@ -9,8 +9,7 @@ plot_heterogeneity(
   axis = x$xvars,
   term = NULL,
   type = "Q",
-  alpha_thresh = 0.05,
-  ...
+  alpha_thresh = 0.05
 )
 }
 \arguments{
@@ -27,8 +26,6 @@ was fitted with a single term, this one is taken.}
 or \code{"p"} for the p-value. Defaults to \code{"Q"}.}
 
 \item{alpha_thresh}{Significance level. Defaults to \code{.05}.}
-
-\item{...}{Other arguments to ggplot.}
 }
 \value{
 A ggplot object.

--- a/man/plot_heterogeneity_p.Rd
+++ b/man/plot_heterogeneity_p.Rd
@@ -4,7 +4,7 @@
 \alias{plot_heterogeneity_p}
 \title{Heterogeneity p-plot}
 \usage{
-plot_heterogeneity_p(data, axis, alpha_thresh, ...)
+plot_heterogeneity_p(data, axis, alpha_thresh)
 }
 \arguments{
 \item{data}{data made by \code{\link{make_heterogeneity_data}}.}
@@ -14,8 +14,6 @@ fitted with a single term, the explanatory variable corresponding to this term
 is selected.}
 
 \item{alpha_thresh}{Significance level. Defaults to \code{.05}.}
-
-\item{...}{Other arguments to ggplot.}
 }
 \value{
 ggproto object

--- a/man/plot_heterogeneity_q.Rd
+++ b/man/plot_heterogeneity_q.Rd
@@ -4,7 +4,7 @@
 \alias{plot_heterogeneity_q}
 \title{Heterogeneity Q-plot}
 \usage{
-plot_heterogeneity_q(data, axis, alpha_thresh, ...)
+plot_heterogeneity_q(data, axis, alpha_thresh)
 }
 \arguments{
 \item{data}{data made by \code{\link{make_heterogeneity_data}}.}
@@ -14,8 +14,6 @@ fitted with a single term, the explanatory variable corresponding to this term
 is selected.}
 
 \item{alpha_thresh}{Significance level. Defaults to \code{.05}.}
-
-\item{...}{Other arguments to ggplot.}
 }
 \value{
 ggproto object

--- a/misc/testdata.R
+++ b/misc/testdata.R
@@ -39,7 +39,8 @@ models <- lapply(list(dat1, dat2, dat3), function(d){
 
 object <- metagam(models)
 
-
+plot_heterogeneity(object, alpha_thresh = .3)
+plot_heterogeneity(object, type = "p")
 #predict(fits[[1]], newdata = tibble(x1 = .5, z = factor(1, levels=1:2)), type = "terms", terms = "s(x1)", newdata.guaranteed = TRUE)
 
 #grid <- expand.grid(replicate(3, seq(from = 0, to = 1, by = .01), simplify = FALSE))


### PR DESCRIPTION
Removed mandatory title from plot_dominance. Setting `title = ""` still leaves space for a title. I hence think it is better to let the user add a title by adding `geom_title()` to the resulting object.